### PR TITLE
View past programs and view past attendees working

### DIFF
--- a/Workforce-Silver-Snakes/Controllers/TrainingProgramsController.cs
+++ b/Workforce-Silver-Snakes/Controllers/TrainingProgramsController.cs
@@ -29,7 +29,7 @@ namespace Workforce_Silver_Snakes.Controllers
             }
         }
         // GET: TrainingPrograms
-        public ActionResult Index()
+        public ActionResult Index(bool past)
         {
             using (SqlConnection conn = Connection)
             {
@@ -39,7 +39,17 @@ namespace Workforce_Silver_Snakes.Controllers
                     cmd.CommandText = @"
                         SELECT Id, [Name], StartDate, EndDate, MaxAttendees
                         FROM TrainingProgram
+                        WHERE 1 = 1
                     ";
+
+                    if (past == true)
+                    {
+                        cmd.CommandText += "AND StartDate < GETDATE()";
+                    }
+                    else
+                    {
+                        cmd.CommandText += "AND StartDate >= GETDATE()";
+                    }
                     SqlDataReader reader = cmd.ExecuteReader();
 
                     List<TrainingProgram> trainingPrograms = new List<TrainingProgram>();

--- a/Workforce-Silver-Snakes/Views/Computers/Index.cshtml
+++ b/Workforce-Silver-Snakes/Views/Computers/Index.cshtml
@@ -11,7 +11,7 @@
 
 <form asp-controller="Computers" asp-action="Index">
     <p>
-        Make or Model: <input type="text" name="SearchString">
+        Make or Model: <input type="text" name="searchString">
         <input type="submit" value="Filter" />
     </p>
 </form>

--- a/Workforce-Silver-Snakes/Views/TrainingPrograms/Details.cshtml
+++ b/Workforce-Silver-Snakes/Views/TrainingPrograms/Details.cshtml
@@ -66,7 +66,7 @@
 <div>
     @if (Model.StartDate > DateTime.Now)
     {
-        @Html.ActionLink("Edit", "Edit", new { id = Model.Id })
+        @Html.ActionLink("Edit", "Edit", new { id = Model.Id }) <span> | </span>
     }
-    | <a asp-action="Index">Back to List</a>
+    <a asp-action="Index" asp-route-past="true">Back to List</a>
 </div>

--- a/Workforce-Silver-Snakes/Views/TrainingPrograms/Details.cshtml
+++ b/Workforce-Silver-Snakes/Views/TrainingPrograms/Details.cshtml
@@ -67,6 +67,11 @@
     @if (Model.StartDate > DateTime.Now)
     {
         @Html.ActionLink("Edit", "Edit", new { id = Model.Id }) <span> | </span>
+        <a asp-action="Index">Back to List</a>
     }
-    <a asp-action="Index" asp-route-past="true">Back to List</a>
+    else
+    {
+        <a asp-action="Index" asp-route-past="true">Back to List</a>
+    }
+
 </div>

--- a/Workforce-Silver-Snakes/Views/TrainingPrograms/Index.cshtml
+++ b/Workforce-Silver-Snakes/Views/TrainingPrograms/Index.cshtml
@@ -9,6 +9,8 @@
 <p>
     <a asp-action="Create">Add Training Program</a>
 </p>
+<a class="btn btn-lg" role="button" asp-action="Index" asp-route-past="true">View Past Programs</a>
+<a class="btn btn-lg" role="button" asp-action="Index">View Future Programs</a>
 <table class="table">
     <thead>
         <tr>
@@ -33,8 +35,6 @@
     <tbody>
         @foreach (var item in Model)
         {
-            @if (item.StartDate > DateTime.Now)
-            {
                 <tr>
                     <td>
                         @Html.DisplayFor(modelItem => item.Id)
@@ -64,7 +64,7 @@
                         }
                     </td>
                 </tr>
-            }
         }
     </tbody>
 </table>
+


### PR DESCRIPTION
# Description
You can now click a button to view past training programs on the training programs index. You can also now click a button to return to viewing future programs.
You can also view attendees of past programs.
Fixes #14 , #15 
## Type of change
Please delete options that are not relevant.
- [✓] New feature (non-breaking change which adds functionality)
# Testing Instructions

- Navigate to index of training programs. Confirm that only future programs are showing.
- Confirm that both 'View Past Programs' and 'View Future Programs' buttons are displaying.
- Click on 'View Past Programs' and confirm that it both added '?past=true' query string param to URL and changed table of programs to only display past programs.
- Click on 'Details' on a past program and confirm that all relevant info is display on the details page, including the program's attendees.
 - Click on 'Back to List' and confirm that it takes you back to the list of past programs and not to the list of future ones.
- Click on 'View Future Programs' and confirm that it removes the query string param '?past=true' from the URL and that it changes the table to display only future programs.

# Checklist:
- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [✓] I have commented my code, particularly in hard-to-understand areas
- [✓] My changes generate no new warnings or errors
- [✓] I have added test instructions that prove my fix is effective or that my feature works
